### PR TITLE
fix: handle AssertionError in parsed_memory_limit gracefully

### DIFF
--- a/onlinejudge_command/subcommand/submit.py
+++ b/onlinejudge_command/subcommand/submit.py
@@ -96,7 +96,12 @@ def run(args: argparse.Namespace) -> bool:
                 return False
 
         # guess or select language ids
-        language_dict: Dict[LanguageId, str] = {language.id: language.name for language in problem.get_available_languages(session=sess)}
+        try:
+            language_dict: Dict[LanguageId, str] = {language.id: language.name for language in problem.get_available_languages(session=sess)}
+        except Exception as e:
+            logger.exception('failed to get available languages: %s', e)
+            logger.error('This may be due to a parsing issue with the problem page. Please try again later or report this issue.')
+            return False
         matched_lang_ids: Optional[List[str]] = None
         if args.language in language_dict:
             matched_lang_ids = [args.language]


### PR DESCRIPTION
Fixes #2

Added exception handling around get_available_languages() call in submit.py to prevent crashes when AtCoder service fails to parse memory limits from HTML.

**Changes:**
- Added try-catch block around problem.get_available_languages() call
- Provides helpful error message instead of raw AssertionError
- Follows existing error handling patterns in codebase

**Testing:**
- Change is minimal and follows established patterns
- Will gracefully handle the AssertionError mentioned in the issue

Generated with [Claude Code](https://claude.ai/code)